### PR TITLE
Fix Helm service targetPort value

### DIFF
--- a/helm/cloudwranglers/templates/service.yaml
+++ b/helm/cloudwranglers/templates/service.yaml
@@ -9,7 +9,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: 8080
+      targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
       name: http
   selector:


### PR DESCRIPTION
## Summary
- use `.Values.service.targetPort` for the service template

## Testing
- `helm template test-release helm/cloudwranglers` *(fails: `helm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68409e1aeab88324a46ef24a1f44e371